### PR TITLE
fix: correctly unmarshal booleans represented as strings or numbers

### DIFF
--- a/porkbun.go
+++ b/porkbun.go
@@ -57,17 +57,46 @@ func (r *ErrorResponse) Error() string {
 // String is a helper function that allocates a new string value and returns a pointer to it.
 func String(v string) *string { return &v }
 
+// unmarshalBool converts JSON data into a boolean value.
+//
+// The Porkbun API represents booleans in two formats:
+// 1. Strings: "1" for true, "0" or "" for false.
+// 2. Numbers: 1 for true, 0 for false.
+// This function handles both formats and returns the appropriate boolean value.
+func unmarshalBool(data []byte) (bool, error) {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		if str == "" {
+			return false, nil
+		}
+		parsedBool, err := strconv.ParseBool(str)
+		if err != nil {
+			return false, fmt.Errorf("error parsing boolean: %s", str)
+		}
+		return parsedBool, nil
+	}
+
+	var num int
+	if err := json.Unmarshal(data, &num); err == nil {
+		switch num {
+		case 0:
+			return false, nil
+		case 1:
+			return true, nil
+		default:
+			return false, fmt.Errorf("error parsing boolean: %d", num)
+		}
+	}
+
+	return false, fmt.Errorf("error invalid boolean format: %s", string(data))
+}
+
 // BoolString is a custom type for handling boolean values represented as "1"/"0" strings in JSON.
 type BoolString bool
 
 // UnmarshalJSON implements custom unmarshalling logic for BoolString.
 func (b *BoolString) UnmarshalJSON(data []byte) error {
-	var str string
-	if err := json.Unmarshal(data, &str); err != nil {
-		return err
-	}
-
-	parsedBool, err := strconv.ParseBool(str)
+	parsedBool, err := unmarshalBool(data)
 	if err != nil {
 		return err
 	}
@@ -80,12 +109,11 @@ type BoolNumber bool
 
 // UnmarshalJSON implements custom unmarshalling logic for BoolNumber.
 func (b *BoolNumber) UnmarshalJSON(data []byte) error {
-	var num int
-	if err := json.Unmarshal(data, &num); err != nil {
+	parsedBool, err := unmarshalBool(data)
+	if err != nil {
 		return err
 	}
-
-	*b = BoolNumber(num == 1)
+	*b = BoolNumber(parsedBool)
 	return nil
 }
 

--- a/porkbun_test.go
+++ b/porkbun_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -122,6 +123,34 @@ func TestBoolNumberWithInvalidValue(t *testing.T) {
 	err := json.Unmarshal([]byte(`"invalid"`), &bn)
 
 	assert.Error(t, err)
+}
+
+func TestUnmarshalBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    bool
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{name: "valid string false", data: []byte(`"false"`), want: false, wantErr: assert.NoError},
+		{name: "valid string true", data: []byte(`"true"`), want: true, wantErr: assert.NoError},
+		{name: "valid string 0", data: []byte(`"0"`), want: false, wantErr: assert.NoError},
+		{name: "valid string 1", data: []byte(`"1"`), want: true, wantErr: assert.NoError},
+		{name: "empty string", data: []byte(`""`), want: false, wantErr: assert.NoError},
+		{name: "invalid string", data: []byte(`"invalid"`), want: false, wantErr: assert.Error},
+		{name: "valid number 0", data: []byte(`0`), want: false, wantErr: assert.NoError},
+		{name: "valid number 1", data: []byte(`1`), want: true, wantErr: assert.NoError},
+		{name: "invalid number", data: []byte(`2`), want: false, wantErr: assert.Error},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := unmarshalBool(tt.data)
+			if !tt.wantErr(t, err, fmt.Sprintf("unmarshalBool(%v)", tt.data)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "unmarshalBool(%v)", tt.data)
+		})
+	}
 }
 
 func TestErrorResponse_ErrorMessage(t *testing.T) {


### PR DESCRIPTION
Fixes an issue where boolean values like `"1"` caused unmarshal errors by incorrectly expecting integers. This commit adds an `unmarshalBool` helper to handle both string and number formats in a unified way.

```
json: cannot unmarshal string into Go struct field ListDomainsResponse.domains.Alias.autoRenew of type int
```
The existing `BoolString` and `BoolNumber` types are kept for API compatibility, but now use a shared parsing function. As a result, `BoolString` can now also handle numeric booleans, and `BoolNumber` can handle string booleans.

They could be replaced by a single `APIBool` type, though that would break backwards compatibility.