### PR TITLE
fix: handle empty create/expire dates during parsing

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -52,14 +52,18 @@ func (d *Domain) UnmarshalJSON(data []byte) error {
 	}
 
 	var err error
-	d.CreateDate, err = time.Parse(timeFormat, aux.CreateDate)
-	if err != nil {
-		return fmt.Errorf("error parsing CreateDate: %w", err)
+	if aux.CreateDate != "" {
+		d.CreateDate, err = time.Parse(timeFormat, aux.CreateDate)
+		if err != nil {
+			return fmt.Errorf("error parsing CreateDate: %w", err)
+		}
 	}
 
-	d.ExpireDate, err = time.Parse(timeFormat, aux.ExpireDate)
-	if err != nil {
-		return fmt.Errorf("error parsing ExpireDate: %w", err)
+	if aux.ExpireDate != "" {
+		d.ExpireDate, err = time.Parse(timeFormat, aux.ExpireDate)
+		if err != nil {
+			return fmt.Errorf("error parsing ExpireDate: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The `create_date` and `expire_date` in the API response seem to be empty in some cases. This PR adds a check to prevent panics in such cases.